### PR TITLE
Apparently the version patterns changed

### DIFF
--- a/Install-Git.ps1
+++ b/Install-Git.ps1
@@ -63,7 +63,7 @@ if (!($IsLinux -or $IsOSX)) {
     $gitExePath = "C:\Program Files\Git\bin\git.exe"
 
     foreach ($asset in (Invoke-RestMethod https://api.github.com/repos/git-for-windows/git/releases/latest).assets) {
-        if ($asset.name -match 'Git-\d*\.\d*\.\d*-64-bit\.exe') {
+        if ($asset.name -match 'Git-\d*\.\d*\.\d*.\d*-64-bit\.exe') {
             $dlurl = $asset.browser_download_url
             $newver = $asset.name
         }


### PR DESCRIPTION
Returned versions currently look like this:

Git-2.14.2.3-32-bit.exe
Git-2.14.2.3-32-bit.tar.bz2
Git-2.14.2.3-64-bit.exe
Git-2.14.2.3-64-bit.tar.bz2
MinGit-2.14.2.3-32-bit.zip
MinGit-2.14.2.3-64-bit.zip
MinGit-2.14.2.3-busybox-32-bit.zip
MinGit-2.14.2.3-busybox-64-bit.zip
PortableGit-2.14.2.3-32-bit.7z.exe
PortableGit-2.14.2.3-64-bit.7z.exe

regex might need an update in a couple of other places as well.